### PR TITLE
See #37.  By default Terraform's terminal output truncates deeply nes…

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -65,12 +65,12 @@ output "confluent_shared_kafka_cluster_id" {
 
 output "sandbox_kafka_cluster_endpoints" {
   description = "Sandbox Kafka Cluster Endpoints"
-  value       = confluent_kafka_cluster.sandbox_cluster.endpoints
+  value       = jsonencode(confluent_kafka_cluster.sandbox_cluster.endpoints)
 }
 
 output "shared_kafka_cluster_endpoints" {
   description = "Shared Kafka Cluster Endpoints"
-  value       = confluent_kafka_cluster.shared_cluster.endpoints
+  value       = jsonencode(confluent_kafka_cluster.shared_cluster.endpoints)
 }
 
 output "deploy_script_arguments" {


### PR DESCRIPTION
…ted objects with (...). Therefore, wrapping in jsonencode() will expose all the endpoints.